### PR TITLE
Allow custom bugsnag.onBeforeNotify hook to be provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,11 @@ import cluster from 'cluster';
 import express from 'express';
 import morgan from 'morgan';
 import util from 'util';
-import uuid from 'node-uuid';
 
 import errorHandler from './error-handler';
 import logger from './logger';
 import setupCluster from './setup-cluster';
-import setupProfiler  from './profiler';
+import setupProfiler from './profiler';
 import { bootstrapConsul } from './config';
 
 import Bluebird from 'bluebird';


### PR DESCRIPTION
This is needed so we can sanitise error messages.
