### PR TITLE
allow non-strings to pass through sanitise untouched

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musicglue/mg-express",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Express stuff used on all musicglue services",
   "main": "lib/index.js",
   "scripts": {

--- a/src/textSanitiser.js
+++ b/src/textSanitiser.js
@@ -1,3 +1,5 @@
+import { isString } from 'lodash';
+
 const cache = {};
 const escapeChars = '\\u001b\\[\\d{1,2}m';
 const splitter = `(?:${escapeChars}|\\s)*:(?:${escapeChars}|\\s)*`;
@@ -64,5 +66,5 @@ export const sanitisers = [
 const sanitiseLine = line => sanitisers.reduce((p, c) => c(p), line);
 
 export default function (text) {
-  return text.split('\n').map(sanitiseLine).join('\n');
+  return isString(text) ? text.split('\n').map(sanitiseLine).join('\n') : text;
 }

--- a/test/textSanitiserTest.js
+++ b/test/textSanitiserTest.js
@@ -1,9 +1,13 @@
-import { expect } from 'chai';
+import dirtyChai from 'dirty-chai';
+import chai, { expect } from 'chai';
+
+chai.use(dirtyChai);
+
 import sanitise from '../src/textSanitiser';
 
 describe('text sanitiser', () => {
   describe('sanitising non-strings', () => {
-    it('returns undefined if given undefined', () => expect(sanitise(undefined)).to.be.undefined);
+    it('returns undefined if given undefined', () => expect(sanitise(undefined)).to.be.undefined());
   });
 
   describe('the error message does not contain anything that looks sensitive', () => {

--- a/test/textSanitiserTest.js
+++ b/test/textSanitiserTest.js
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import sanitise from '../src/textSanitiser';
 
-describe('error sanitiser', () => {
+describe('text sanitiser', () => {
+  describe('sanitising non-strings', () => {
+    it('returns undefined if given undefined', () => expect(sanitise(undefined)).to.be.undefined);
+  });
+
   describe('the error message does not contain anything that looks sensitive', () => {
     const text = 'foo is blah pass word cvx cord number';
 


### PR DESCRIPTION
at the moment, if you call `sanitise` with something that is not a string it will catch 🔥 . this pr fixes it to act like `x => x` if `x` is not a string.